### PR TITLE
Use white background in "layout_border" drawable

### DIFF
--- a/app/src/main/res/drawable/layout_border.xml
+++ b/app/src/main/res/drawable/layout_border.xml
@@ -5,4 +5,6 @@
     <stroke
         android:width="2dp"
         android:color="#727272"/>
+    <solid
+        android:color="#ffffff"/>
 </shape>


### PR DESCRIPTION
This solves the "black rectangle" issue in openwebnet/openwebnet-android#1.