### PR TITLE
Let custom widgets inherit from AppCompat widgets

### DIFF
--- a/app/src/main/java/com/github/openwebnet/view/custom/EditTextCustom.java
+++ b/app/src/main/java/com/github/openwebnet/view/custom/EditTextCustom.java
@@ -1,12 +1,13 @@
 package com.github.openwebnet.view.custom;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatEditText;
 import android.util.AttributeSet;
 import android.widget.EditText;
 
 import com.github.openwebnet.R;
 
-public class EditTextCustom extends EditText {
+public class EditTextCustom extends AppCompatEditText {
 
     public EditTextCustom(Context context, AttributeSet attrs) {
         super(context, attrs);

--- a/app/src/main/java/com/github/openwebnet/view/custom/TextViewCustom.java
+++ b/app/src/main/java/com/github/openwebnet/view/custom/TextViewCustom.java
@@ -1,12 +1,13 @@
 package com.github.openwebnet.view.custom;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
 import com.github.openwebnet.R;
 
-public class TextViewCustom extends TextView {
+public class TextViewCustom extends AppCompatTextView {
 
     public TextViewCustom(Context context, AttributeSet attrs) {
         super(context, attrs);


### PR DESCRIPTION
AppCompat widgets seems to be consistent across API levels.
Fixes openwebnet/openwebnet-android#28.